### PR TITLE
Move handling of transaction to an async process

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A GET request to this endpoint will return a JSON array of objects containing a 
 
 ## [receipt.php](receipt.php)
 
-When a transaction is processed in Authorize.net, it is configured to POST a `net.authorize.payment.authcapture.created` event to this endpoint as a webhook. In order to immediately signal to Authorize.net that the notification is being processed, this endpoint passes the transaction id to the [record_alma_transactions.php](record_alma_transactions.php) script using `shell_exec`, and immediately returns a 200 result. The new process gets the transaction data based on the ID contained in the event, then updates the Alma fees to be paid based on that transaction data.
+When a transaction is processed in Authorize.net, it is configured to POST a `net.authorize.payment.authcapture.created` event to this endpoint as a webhook. In order to immediately signal to Authorize.net that the notification is being processed, this endpoint passes the transaction id to the [record_alma_transactions.php](record_alma_transactions.php) script using `proc_open`, and immediately returns a 200 result. The new process gets the transaction data based on the ID contained in the event, then updates the Alma fees to be paid based on that transaction data.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A GET request to this endpoint will return a JSON array of objects containing a 
 
 ## [receipt.php](receipt.php)
 
-When a transaction is processed in Authorize.net, it is configured to POST a `net.authorize.payment.authcapture.created` event to this endpoint as a webhook. This endpoint gets the transaction data based on the ID contained in the event, then updates the Alma fees to be paid based on that transaction data.
+When a transaction is processed in Authorize.net, it is configured to POST a `net.authorize.payment.authcapture.created` event to this endpoint as a webhook. In order to immediately signal to Authorize.net that the notification is being processed, this endpoint passes the transaction id to the [record_alma_transactions.php](record_alma_transactions.php) script using `shell_exec`, and immediately returns a 200 result. The new process gets the transaction data based on the ID contained in the event, then updates the Alma fees to be paid based on that transaction data.
 
 ## License
 

--- a/common.php
+++ b/common.php
@@ -134,3 +134,14 @@ function isAllowed(string $libraryCode): bool {
         return true;
     }
 }
+
+/**
+ * Write an error to the webhook error log.
+ * @param Throwable|string $error
+ */
+function logWebhookError($error) {
+    if (defined('WEBHOOK_ERROR_LOG_PATH')) {
+        $error_message = date('[Y-m-d h:m:s] ') . $error . "\n";
+        file_put_contents(WEBHOOK_ERROR_LOG_PATH, $error_message, FILE_APPEND);
+    }
+}

--- a/common.php
+++ b/common.php
@@ -145,3 +145,14 @@ function logWebhookError($error) {
         file_put_contents(WEBHOOK_ERROR_LOG_PATH, $error_message, FILE_APPEND);
     }
 }
+
+/**
+ * Mails an error report to the configured recipient.
+ * @param string $subject
+ * @param Throwable|string $error
+ */
+function mailWebhookError($subject, $error) {
+    if (defined('WEBHOOK_ERROR_NOTIFICATION_EMAIL')) {
+        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, $subject, $error);
+    }
+}

--- a/config.sample.php
+++ b/config.sample.php
@@ -15,7 +15,8 @@ define('ALLOWED_LIBRARY_CODES', ['array of library codes', 'whose fees may be pa
 define('EXCLUDED_LIBRARY_CODES', ['array of library codes', 'whose fees may NOT be paid using this service']);
 // Optional, for those cases where a minimum amount is desired due to payment processor fees, etc.
 define('MINIMUM_TOTAL_AMOUNT', 5.00);
-define('WEBHOOK_LOG_PATH', 'receipt_webhook.log');
+define('WEBHOOK_NOTIFICATION_LOG_PATH', 'notification.log');
+define('WEBHOOK_OUTPUT_LOG_PATH', 'receipt_webhook_output.log');
 define('WEBHOOK_ERROR_LOG_PATH', 'receipt_webhook_error.log');
 define('WEBHOOK_ERROR_NOTIFICATION_EMAIL', 'example@example.com');
 ?>

--- a/config.sample.php
+++ b/config.sample.php
@@ -17,4 +17,5 @@ define('EXCLUDED_LIBRARY_CODES', ['array of library codes', 'whose fees may NOT 
 define('MINIMUM_TOTAL_AMOUNT', 5.00);
 define('WEBHOOK_LOG_PATH', 'receipt_webhook.log');
 define('WEBHOOK_ERROR_LOG_PATH', 'receipt_webhook_error.log');
+define('WEBHOOK_ERROR_NOTIFICATION_EMAIL', 'example@example.com');
 ?>

--- a/index.php
+++ b/index.php
@@ -187,7 +187,7 @@ function getAuthorizeTransactionToken($user, $fees, $hosted_payment_settings_key
     
     // invoice number based on the microsecond
     $order = new AnetAPI\OrderType();
-    $order->setInvoiceNumber('A' . microtime(true) * 10000);
+    $order->setInvoiceNumber('ALMA' . microtime(true) * 10000);
     $transactionRequest->setOrder($order);
 
     // set the alma user id as the customer id, will be retrieved in the receipt webhook

--- a/index.php
+++ b/index.php
@@ -231,7 +231,7 @@ function getAuthorizeTransactionToken($user, $fees, $hosted_payment_settings_key
     } else if ($response != null) {
         $exceptionMessage = '';
         foreach ($response->getMessages()->getMessage() as $errorMessage) {
-            $exceptionMessage = $exceptionMessage . $errorMessage->getCode() . " " . $errorMessage->getText() . "\n";
+            $exceptionMessage .= $errorMessage->getCode() . " " . $errorMessage->getText() . "\n";
         }
         throw new Exception($exceptionMessage);      
     } else {

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ if ($method === 'OPTIONS') {
     http_response_code(200);
     exit;
 } else if (!in_array($method, ['GET', 'POST'])) {    
-    http_response_code(400);
+    http_response_code(405);
     exit;
 }
 
@@ -35,7 +35,7 @@ try {
         } else if ($contentType == 'application/x-www-form-urlencoded') {
             $body = $_POST;
         } else {
-            http_response_code('415');
+            http_response_code(415);
             exit;
         }
     }

--- a/index.php
+++ b/index.php
@@ -229,8 +229,11 @@ function getAuthorizeTransactionToken($user, $fees, $hosted_payment_settings_key
     if ($response != null && $response->getMessages()->getResultCode() == "Ok") {
         return $response->getToken();
     } else if ($response != null) {
-        $errorMessages = $response->getMessages()->getMessage();
-        throw new Exception($errorMessages[0]->getCode() . " " . $errorMessages[0]->getText());        
+        $exceptionMessage = '';
+        foreach ($response->getMessages()->getMessage() as $errorMessage) {
+            $exceptionMessage = $exceptionMessage . $errorMessage->getCode() . " " . $errorMessage->getText() . "\n";
+        }
+        throw new Exception($exceptionMessage);      
     } else {
         throw new Exception("An error occurred when requesting a hosted payment page token.");
     }

--- a/receipt.php
+++ b/receipt.php
@@ -30,6 +30,8 @@ try {
         case 'net.authorize.payment.authcapture.created':
             $transactionId = $notification->payload->id;
 
+            shell_exec('php record_alma_transaction.php ' . $transactionId . ' 2>&1 | tee -a record_transaction.log 2>/dev/null >/dev/null &');
+/*
             $request = new AnetApi\GetTransactionDetailsRequest();
             $request->setMerchantAuthentication(getMerchantAuthentication());
             $request->setTransId($transactionId);
@@ -59,7 +61,7 @@ try {
                 ]);
                 $alma->post($url, null);
             }
-
+*/
             break;
         
         default:
@@ -74,7 +76,7 @@ try {
         if (isset($notification)) {
             $error_message = $notification->notificationId . ': ' . $error_message;
         }
-        file_put_contents(WEBHOOK_ERROR_LOG_PATH, $error_message, FILE_APPEND);
+        file_put_contents(WEBHOOK_ERROR_LOG_PATH, date('[Y-m-d h:m:s] ') . $error_message, FILE_APPEND);
     }
     http_response_code(500);
     exit;

--- a/receipt.php
+++ b/receipt.php
@@ -1,9 +1,6 @@
 <?php
 
 require_once 'common.php';
-use Scriptotek\Alma\Client as AlmaClient;
-use net\authorize\api\contract\v1 as AnetAPI;
-use net\authorize\api\controller as AnetController;
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(400);

--- a/receipt.php
+++ b/receipt.php
@@ -3,7 +3,7 @@
 require_once 'common.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(400);
+    http_response_code(405);
     exit;
 }
 
@@ -17,8 +17,8 @@ try {
     $signature = substr($signatureHeader, 7);
     $hash = hash_hmac("sha512", $body, AUTHORIZE_SIGNATURE_KEY);
     if (strcasecmp($signature, $hash) !== 0) {
-        // return bad request if signature does not match
-        http_response_code(400);
+        // return unauthorized if signature does not match
+        http_response_code(401);
         exit;
     }
 

--- a/receipt.php
+++ b/receipt.php
@@ -26,39 +26,7 @@ try {
     switch ($notification->eventType) {
         case 'net.authorize.payment.authcapture.created':
             $transactionId = $notification->payload->id;
-
             shell_exec('php record_alma_transaction.php ' . $transactionId . ' 2>&1 | tee -a record_transaction.log 2>/dev/null >/dev/null &');
-/*
-            $request = new AnetApi\GetTransactionDetailsRequest();
-            $request->setMerchantAuthentication(getMerchantAuthentication());
-            $request->setTransId($transactionId);
-
-            // get the transaction details so we can read the fee ids off of the line items
-            $controller = new AnetController\GetTransactionDetailsController($request);
-            $response = $controller->executeWithApiResponse(AUTHORIZE_ENVIRONMENT);
-
-            if ($response == null) {
-                throw new Exception("An error occurred when retrieving transaction details.");
-            } else if ($response->getMessages()->getResultCode() != "Ok") {
-                $errorMessages = $response->getMessages()->getMessage();
-                throw new Exception($errorMessages[0]->getCode() . " " . $errorMessages[0]->getText());        
-            }
-
-            $transaction = $response->getTransaction();
-            $userId = $transaction->getCustomer()->getId();
-            $alma = new AlmaClient(ALMA_API_KEY, ALMA_REGION);
-            foreach ($transaction->getLineItems() as $lineItem) {
-                $feeId = $lineItem->getItemId();
-                // mark each fee as paid
-                $url = $alma->buildUrl('/users/' . $userId . '/fees/' . $feeId, [
-                    'op' => 'pay',
-                    'amount' => strval($lineItem->getUnitPrice()),
-                    'method' => 'ONLINE',
-                    'external_transaction_id' => $transactionId
-                ]);
-                $alma->post($url, null);
-            }
-*/
             break;
         
         default:

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -1,6 +1,9 @@
 <?php
 
 require_once 'common.php';
+use Scriptotek\Alma\Client as AlmaClient;
+use net\authorize\api\contract\v1 as AnetAPI;
+use net\authorize\api\controller as AnetController;
 
 if (isset($_SERVER['REQUEST_METHOD'])) {
     http_response_code(404);

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once 'common.php';
+
+if (isset($_SERVER['REQUEST_METHOD'])) {
+    http_response_code(404);
+    exit;
+}
+
+try {
+    $transactionId = $argv[1];
+
+    $request = new AnetApi\GetTransactionDetailsRequest();
+    $request->setMerchantAuthentication(getMerchantAuthentication());
+    $request->setTransId($transactionId);
+
+    // get the transaction details so we can read the fee ids off of the line items
+    $controller = new AnetController\GetTransactionDetailsController($request);
+    $response = $controller->executeWithApiResponse(AUTHORIZE_ENVIRONMENT);
+
+    if ($response == null) {
+        throw new Exception("An error occurred when retrieving transaction details.");
+    } else if ($response->getMessages()->getResultCode() != "Ok") {
+        $errorMessages = $response->getMessages()->getMessage();
+        throw new Exception($errorMessages[0]->getCode() . " " . $errorMessages[0]->getText());        
+    }
+
+    $transaction = $response->getTransaction();
+    $userId = $transaction->getCustomer()->getId();
+    $alma = new AlmaClient(ALMA_API_KEY, ALMA_REGION);
+    foreach ($transaction->getLineItems() as $lineItem) {
+        $feeId = $lineItem->getItemId();
+        // mark each fee as paid
+        $url = $alma->buildUrl('/users/' . $userId . '/fees/' . $feeId, [
+            'op' => 'pay',
+            'amount' => strval($lineItem->getUnitPrice()),
+            'method' => 'ONLINE',
+            'external_transaction_id' => $transactionId
+        ]);
+        $alma->post($url, null);
+    }
+} catch (Throwable $e) {
+    if (defined('WEBHOOK_ERROR_LOG_PATH')) {
+        $error_message = date('[Y-m-d h:m:s] ') . $e . "\n";
+        file_put_contents(WEBHOOK_ERROR_LOG_PATH, $error_message, FILE_APPEND);
+    }
+    if (defined('WEBHOOK_ERROR_NOTIFICATION_EMAIL')) {
+        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, 'Alma Payment Receipt Webhook Error', $e);
+    }
+}

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -24,8 +24,11 @@ try {
     if ($response == null) {
         throw new Exception("An error occurred when retrieving transaction details.");
     } else if ($response->getMessages()->getResultCode() != "Ok") {
-        $errorMessages = $response->getMessages()->getMessage();
-        throw new Exception($errorMessages[0]->getCode() . " " . $errorMessages[0]->getText());        
+        $exceptionMessage = '';
+        foreach ($response->getMessages()->getMessage() as $errorMessage) {
+            $exceptionMessage = $exceptionMessage . $errorMessage->getCode() . " " . $errorMessage->getText() . "\n";
+        }
+        throw new Exception($exceptionMessage);        
     }
 
     $transaction = $response->getTransaction();

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -51,6 +51,6 @@ try {
         file_put_contents(WEBHOOK_ERROR_LOG_PATH, $error_message, FILE_APPEND);
     }
     if (defined('WEBHOOK_ERROR_NOTIFICATION_EMAIL')) {
-        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, 'Alma Payment Receipt Webhook Error', $e);
+        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, 'Alma Payment Receipt Webhook Error for Transaction ' . $transactionId, $e);
     }
 }

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -47,7 +47,5 @@ try {
     }
 } catch (Throwable $error) {
     logWebhookError($error);
-    if (defined('WEBHOOK_ERROR_NOTIFICATION_EMAIL')) {
-        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, 'Alma Payment Receipt Webhook Error for Transaction ' . $transactionId, $error);
-    }
+    mailWebhookError('Alma Payment Receipt Webhook Error for Transaction ' . $transactionId, $error);
 }

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -26,6 +26,9 @@ try {
     }
 
     $transaction = $response->getTransaction();
+    if (substr($transaction->getOrder()->getInvoiceNumber(), 0, 4) != 'ALMA') {
+        exit;
+    }
     $userId = $transaction->getCustomer()->getId();
     $alma = new AlmaClient(ALMA_API_KEY, ALMA_REGION);
     foreach ($transaction->getLineItems() as $lineItem) {

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -45,12 +45,9 @@ try {
         ]);
         $alma->post($url, null);
     }
-} catch (Throwable $e) {
-    if (defined('WEBHOOK_ERROR_LOG_PATH')) {
-        $error_message = date('[Y-m-d h:m:s] ') . $e . "\n";
-        file_put_contents(WEBHOOK_ERROR_LOG_PATH, $error_message, FILE_APPEND);
-    }
+} catch (Throwable $error) {
+    logWebhookError($error);
     if (defined('WEBHOOK_ERROR_NOTIFICATION_EMAIL')) {
-        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, 'Alma Payment Receipt Webhook Error for Transaction ' . $transactionId, $e);
+        mail(WEBHOOK_ERROR_NOTIFICATION_EMAIL, 'Alma Payment Receipt Webhook Error for Transaction ' . $transactionId, $error);
     }
 }

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -26,7 +26,7 @@ try {
     } else if ($response->getMessages()->getResultCode() != "Ok") {
         $exceptionMessage = '';
         foreach ($response->getMessages()->getMessage() as $errorMessage) {
-            $exceptionMessage = $exceptionMessage . $errorMessage->getCode() . " " . $errorMessage->getText() . "\n";
+            $exceptionMessage .= $errorMessage->getCode() . " " . $errorMessage->getText() . "\n";
         }
         throw new Exception($exceptionMessage);        
     }

--- a/record_alma_transaction.php
+++ b/record_alma_transaction.php
@@ -6,7 +6,7 @@ use net\authorize\api\contract\v1 as AnetAPI;
 use net\authorize\api\controller as AnetController;
 
 if (isset($_SERVER['REQUEST_METHOD'])) {
-    http_response_code(404);
+    http_response_code(403);
     exit;
 }
 


### PR DESCRIPTION
This pull request moves most of the code that processes a completed transaction out of receipt.php and into another script that is invoked by shell_exec, so the webhook can report that a notification was received while it is being processed asynchronously. It also checks that the transaction's invoice number begins with the string "ALMA".